### PR TITLE
Update versions for 6.0.0 release and update get nodes query

### DIFF
--- a/src/README.rst
+++ b/src/README.rst
@@ -21,6 +21,7 @@ Change Log
 - Add application health policies parameter for config upgrade, which are available in Service Fabric runtime 6.3 (#92)
 - Add command "sfctl cluster show-connection". Command shows the currently connected cluster connection. Nothing is returned if no endpoint is set (#103)
 - Add command override "sfctl --version" to see the current sfctl version (#104)
+- Add parameter to set max results for query "sfctl node list" (#113)
 
 5.0.0
 -----

--- a/src/README.rst
+++ b/src/README.rst
@@ -19,8 +19,8 @@ Change Log
 6.0.0
 -----
 - Add application health policies parameter for config upgrade, which are available in Service Fabric runtime 6.3 (#92)
-- Add command sfctl cluster show-connection. Command shows the currently connected cluster connection. Nothing is returned if no endpoint is set (#103)
-- Add command to see the current version (#104)
+- Add command "sfctl cluster show-connection". Command shows the currently connected cluster connection. Nothing is returned if no endpoint is set (#103)
+- Add command override "sfctl --version" to see the current sfctl version (#104)
 
 5.0.0
 -----

--- a/src/README.rst
+++ b/src/README.rst
@@ -16,7 +16,7 @@ To get started, after installation run the following:
 Change Log
 ==========
 
-Unreleased
+6.0.0
 -----
 - Add application health policies parameter for config upgrade, which are available in Service Fabric runtime 6.3 (#92)
 - Add command sfctl cluster show-connection. Command shows the currently connected cluster connection. Nothing is returned if no endpoint is set (#103)

--- a/src/setup.py
+++ b/src/setup.py
@@ -17,7 +17,7 @@ def read(fname):
 
 setup(
     name='sfctl',
-    version='5.0.0',
+    version='6.0.0',
     description='Azure Service Fabric command line',
     long_description=read('README.rst'),
     url='https://github.com/Azure/service-fabric-cli',
@@ -47,7 +47,7 @@ setup(
         'msrest>=0.4.26',
         'msrestazure',
         'requests',
-        'azure-servicefabric==6.2.0.0',
+        'azure-servicefabric==6.3.0.0',
         'jsonpickle',
         'adal',
         'future'

--- a/src/sfctl/params.py
+++ b/src/sfctl/params.py
@@ -59,6 +59,9 @@ def custom_arguments(self, _):  # pylint: disable=too-many-statements
     with ArgumentsContext(self, 'application deployed-list') as arg_context:
         arg_context.argument('max_results', type=int)
 
+    with ArgumentsContext(self, 'node list') as arg_context:
+        arg_context.argument('max_results', type=int)
+
     with ArgumentsContext(self, 'application list') as arg_context:
         arg_context.argument('application_definition_kind_filter', type=int)
         arg_context.argument('max_results', type=int)

--- a/src/sfctl/tests/request_generation_test.py
+++ b/src/sfctl/tests/request_generation_test.py
@@ -331,10 +331,10 @@ class ServiceFabricRequestTests(ScenarioTest):
             '/Nodes/nodeName',
             ['api-version=6.0'])
         self.validate_command(  # list
-            'sfctl node list --continuation-token=nodeId --node-status-filter=up',
+            'sfctl node list --continuation-token=nodeId --node-status-filter=up --max-results=3',
             'GET',
             '/Nodes',
-            ['api-version=6.0', 'ContinuationToken=nodeId', 'NodeStatusFilter=up'])
+            ['api-version=6.3', 'ContinuationToken=nodeId', 'NodeStatusFilter=up', 'MaxResults=3'])
         self.validate_command(  # load
             'sfctl node load --node-name=nodeName',
             'GET',

--- a/src/sfctl/tests/version_test.py
+++ b/src/sfctl/tests/version_test.py
@@ -15,7 +15,7 @@ class VersionTests(unittest.TestCase):
 
         note: this will require changing the sfctl_version on releases
         """
-        sfctl_version = '5.0.0'
+        sfctl_version = '6.0.0'
 
         pipe = Popen('sfctl --version', shell=True, stdout=PIPE, stderr=PIPE)
         # returned_string and err are returned as bytes


### PR DESCRIPTION
Changes include:

- Update release notes and versions for 6.0.0 release.
- Add parameter to set max results for query "sfctl node list"

Verifed:

- [ ] Build and test CI passes
- [x] History and readme updated to reflect changes
- [x] Package version updated according to semantic versioning rules
- [x] Tests modified or added, when applicable
- [x] Updated code owners file, when applicable
- [x] Read the [PR checklist](https://github.com/Azure/service-fabric-cli/wiki/Checklist)
