### PR TITLE
Help text update

### DIFF
--- a/src/sfctl/custom_cluster.py
+++ b/src/sfctl/custom_cluster.py
@@ -53,7 +53,7 @@ def select(endpoint, cert=None, key=None, pem=None, ca=None, #pylint: disable=in
     #pylint: disable-msg=too-many-locals
     """
     Connects to a Service Fabric cluster endpoint.
-    If connecting to secure cluster specify an absolute path to a cert (.crt)
+    If connecting to secure cluster, specify an absolute path to a cert (.crt)
     and key file (.key) or a single file with both (.pem). Do not specify both.
     Optionally, if connecting to a secure cluster, specify also an absolute
     path to a CA bundle file or directory of trusted CA certs.

--- a/src/sfctl/custom_service.py
+++ b/src/sfctl/custom_service.py
@@ -355,7 +355,7 @@ def create(  # pylint: disable=too-many-arguments, too-many-locals
     :param str int_scheme_high: The end of the key integer range, if using an
     uniform integer partition scheme.
     :param str int_scheme_count: The number of partitions inside the integer
-    key range to create, if using an uniform integer partition scheme.
+    key range to create, if using a uniform integer partition scheme.
     :param str constraints: The placement constraints as a string. Placement
     constraints are boolean expressions on node properties and allow for
     restricting a service to particular nodes based on the service
@@ -632,7 +632,7 @@ def package_upload(client, node_name, service_manifest_name, app_type_name, #pyl
     :param str share_policy: JSON encoded list of sharing policies. Each
     sharing policy element is composed of a 'name' and 'scope'. The name
     corresponds to the name of the code, configuration, or data package that
-    is to be shared. The scope can either 'None', 'All', 'Code', 'Config' or
+    is to be shared. The scope can be either 'None', 'All', 'Code', 'Config' or
     'Data'.
     """
     from azure.servicefabric.models.deploy_service_package_to_node_description import DeployServicePackageToNodeDescription #pylint: disable=line-too-long

--- a/src/sfctl/helps/app.py
+++ b/src/sfctl/helps/app.py
@@ -53,7 +53,7 @@ helps['application upgrade'] = """
       that upgrade description replaces the existing application description.
       This means that if the parameters are not specified, the existing
       parameters on the applications will be overwritten with the empty
-      parameters list. This would results in application using the default
+      parameters list. This would result in the application using the default
       value of the parameters from the application manifest.
     parameters:
         - name: --application-id

--- a/src/sfctl/helps/container.py
+++ b/src/sfctl/helps/container.py
@@ -23,7 +23,7 @@ helps['container invoke-api'] = """
           short-summary: service manifest name
         - name: --code-package-name
           type: string
-          short-summary: code packge name
+          short-summary: code package name
         - name: --code-package-instance-id
           type: string
           short-summary: code package instance ID, which can be retrieved by 'service code-package-list'
@@ -56,7 +56,7 @@ helps['container logs'] = """
           short-summary: service manifest name
         - name: --code-package-name
           type: string
-          short-summary: code packge name
+          short-summary: code package name
         - name: --code-package-instance-id
           type: string
           short-summary: code package instance ID, which can be retrieved by 'service code-package-list'

--- a/src/sfctl/helps/infrastructure.py
+++ b/src/sfctl/helps/infrastructure.py
@@ -29,7 +29,7 @@ helps['is command'] = """
           short-summary: The identity of the infrastructure service.
           long-summary: This is the full name of the infrastructure service
             without the 'fabric' URI scheme. This parameter required only for
-            the cluster that have more than one instance of infrastructure
+            the cluster that has more than one instance of infrastructure
             service running.
 """
 
@@ -54,6 +54,6 @@ helps['is query'] = """
           short-summary: The identity of the infrastructure service.
           long-summary: This is the full name of the infrastructure service
             without the 'fabric:' URI scheme. This parameter required only for
-            the cluster that have more than one instance of infrastructure
+            the cluster that has more than one instance of infrastructure
             service running.
 """

--- a/src/sfctl/helps/main.py
+++ b/src/sfctl/helps/main.py
@@ -11,7 +11,7 @@ from knack.help_files import helps
 helps[''] = """
     type: group
     short-summary: Commands for managing Service Fabric clusters
-        and entities. This version is compatible with Service Fabric 6.2
+        and entities. This version is compatible with Service Fabric 6.3
         runtime.
     long-summary: Commands follow the noun-verb pattern. See subgroups for more
         information.
@@ -29,13 +29,12 @@ helps['sa-cluster'] = """
 
 helps['application'] = """
     type: group
-    short-summary: Create, delete, and manage applications and application
-        types
+    short-summary: Create, delete, and manage applications and application types.
 """
 
 helps['chaos'] = """
     type: group
-    short-summary: Start, stop and report on the chaos test service
+    short-summary: Start, stop, and report on the chaos test service
 """
 
 helps['chaos schedule'] = """
@@ -45,17 +44,17 @@ helps['chaos schedule'] = """
 
 helps['cluster'] = """
     type: group
-    short-summary: Select, manage and operate Service Fabric clusters
+    short-summary: Select, manage, and operate Service Fabric clusters
 """
 
 helps['compose'] = """
     type: group
-    short-summary: Create, delete and manage Docker Compose applications
+    short-summary: Create, delete, and manage Docker Compose applications
 """
 
 helps['container'] = """
     type: group
-    short-summary: run container related commands on a cluster node
+    short-summary: Run container related commands on a cluster node
 """
 
 helps['is'] = """


### PR DESCRIPTION
Changes include:

- Add some fixes to the documentation. This includes a typo in the main help text about which version this release (6.0.0) should target.

Verifed:

- [ ] Build and test CI passes
- [ ] History and readme updated to reflect changes
- [ ] Package version updated according to semantic versioning rules
- [ ] Tests modified or added, when applicable
- [ ] Updated code owners file, when applicable
- [ ] Read the [PR checklist](https://github.com/Azure/service-fabric-cli/wiki/Checklist)
