### PR TITLE
Fix missing enum value in report health

### DIFF
--- a/src/README.rst
+++ b/src/README.rst
@@ -24,7 +24,7 @@ Unreleased
 - Add Mesh app, volume, service, and service-replica commands (#129)
 - Add Mesh network, gateway, code package, secret, and secretvalue commands (#141)
 - Allow any Python 3.7.x versions rather than only 3.7.0 (#142)
-- Fix missing enum option of "Error" in health reporting (#151)
+- Fix missing option of "Error" health state in health reporting (#151)
 
 6.0.1
 -----

--- a/src/README.rst
+++ b/src/README.rst
@@ -24,6 +24,7 @@ Unreleased
 - Add Mesh app, volume, service, and service-replica commands (#129)
 - Add Mesh network, gateway, code package, secret, and secretvalue commands (#141)
 - Allow any Python 3.7.x versions rather than only 3.7.0 (#142)
+- Fix missing enum option of "Error" in health reporting (#151)
 
 6.0.1
 -----

--- a/src/sfctl/custom_health.py
+++ b/src/sfctl/custom_health.py
@@ -77,7 +77,7 @@ def create_health_information(source_id, health_property, health_state, ttl, #py
     """Validates and creates a health information object"""
     from azure.servicefabric.models.health_information import HealthInformation
 
-    if health_state not in ['Invalid', 'Ok', 'Warning', 'Unknown']:
+    if health_state not in ['Invalid', 'Ok', 'Warning', 'Error', 'Unknown']:
         raise CLIError('Invalid health state specified')
 
     return HealthInformation(source_id=source_id,


### PR DESCRIPTION
Fixes # .

Changes include:

- Allow reporting on "Error" state for report health on entities

Verified:

- [ ] Build and test CI passes
- [ ] History and readme updated to reflect changes
- [ ] Package version updated according to semantic versioning rules
- [ ] Tests modified or added, when applicable
- [ ] Updated code owners file, when applicable
- [ ] Read the [PR checklist](https://github.com/Azure/service-fabric-cli/wiki/Checklist)
