### PR TITLE
Fix test issue where the correct issue is not being verified for

### DIFF
--- a/src/sfctl/custom_cluster.py
+++ b/src/sfctl/custom_cluster.py
@@ -262,7 +262,7 @@ def sfctl_cluster_version_matches(cluster_version, sfctl_version):
 
     if sfctl_version == '7.0.0':
 
-        return cluster_version.startswith('6.5')
+        return cluster_version.startswith('6.4')
 
     # If we forget to update this code before a new release, the tests which call this method
     # will fail.

--- a/src/sfctl/tests/cluster_test.py
+++ b/src/sfctl/tests/cluster_test.py
@@ -61,7 +61,11 @@ class ClusterTests(unittest.TestCase):
 
         # An exception will be raised if the current cluster version doesn't exist in the function
         try:
-            sfctl_cluster_version_matches('6.4', current_sfctl_version)
+            self.assertTrue(sfctl_cluster_version_matches('6.4', current_sfctl_version),
+                            msg='You are most likely getting this error because we need to '
+                                'update the method sfctl_cluster_version_matches in '
+                                'custom_cluster so that it works with the '
+                                'current version of sfctl, or we need to update this test.')
         except SFCTLInternalException as ex:
             # Give a more test appropriate error message
             self.fail(ex.message + ' You are most likely getting this error because we need to '


### PR DESCRIPTION
Fixes PR #123 .

Changes include:

- Fix a typo
- Fix a test that was not correctly catching the typo because it wasn't correctly checking the return value.

Verified:

- [ ] Build and test CI passes
- [ ] History and readme updated to reflect changes
- [ ] Package version updated according to semantic versioning rules
- [ ] Tests modified or added, when applicable
- [ ] Updated code owners file, when applicable
- [ ] Read the [PR checklist](https://github.com/Azure/service-fabric-cli/wiki/Checklist)
