### PR TITLE
Add batched telemetry

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -54,7 +54,8 @@ setup(
         'future',
         'applicationinsights',
         'sfmergeutility',
-        'psutil'
+        'psutil',
+        'portalocker'
     ],
     extras_require={
         'test': [

--- a/src/sfctl/send_telemetry_background.py
+++ b/src/sfctl/send_telemetry_background.py
@@ -32,8 +32,8 @@ def read_telemetry_entries():
     return_tuples = []
 
     # Mode r starts at the beginning of the file
-    with portalocker.Lock(TELEMETRY_FILE_PATH, timeout=1, fail_when_locked=True, mode='r') as file:
-        all_lines = file.readlines()
+    with portalocker.Lock(TELEMETRY_FILE_PATH, timeout=1, fail_when_locked=True, mode='r') as telemetry_file:  # pylint: disable=line-too-long
+        all_lines = telemetry_file.readlines()
 
         # Parse the lines. The lines have format {0}, {1}
         for line in all_lines:

--- a/src/sfctl/send_telemetry_background.py
+++ b/src/sfctl/send_telemetry_background.py
@@ -7,71 +7,96 @@
 """A script which sends telemetry in the background as a new process.
 This process should end itself in SINGLE_UPLOAD_TIMEOUT seconds for single telemetry calls."""
 
-import sys
-from uuid import uuid4
+import os
+import json
 from multiprocessing import Process
+import portalocker
 from applicationinsights import TelemetryClient
-from sfctl.config import get_cli_version_from_pkg
+from sfctl.telemetry import TELEMETRY_FILE_PATH
+from sfctl.state import set_telemetry_send_retry_count
 
 INSTRUMENTATION = '482faeea-c22b-4c75-a1af-5bfe79f36cb7'
-SINGLE_UPLOAD_TIMEOUT = 15
+SINGLE_UPLOAD_TIMEOUT = 30
 
-
-def send_telemetry_best_attempt(command_name, telemetry_data):
+def read_telemetry_entries():
     """
-    Sends telemetry without retry. On failure, telemetry data is lost, and no records are kept.
+    Read and return the telemetry entries.
 
-    :param command_name: (str) the command_name being called, without parameters.
-        For example, 'node show'
-    :param telemetry_data: (dict) Dict containing the following data, where all inputs are str
-        {'success': call_success,
-         'operating_system': platform,
-         'python_version': python_version,
-         'operation_id': operation_id,
-         'error_msg': error_msg,
-         'sfctl_version': version}
+    :return: List[(str, dict)] returns a list of tuples representing the input
+        to the track_event command for the application insights telemetry client.
+        Each tuple contains the following:
+            (str) the command_name being called, without parameters. For example, 'node show'
+            (dict) See return from get_telemetry_input_as_dict()
+    """
+
+    return_tuples = []
+
+    # Mode r starts at the beginning of the file
+    with portalocker.Lock(TELEMETRY_FILE_PATH, timeout=1, fail_when_locked=True, mode='r') as file:
+        all_lines = file.readlines()
+
+        # Parse the lines. The lines have format {0}, {1}
+        for line in all_lines:
+            if line.strip():  # ignore any empty lines
+                index_of_first_comma = line.find(',')
+                command_name = line[:index_of_first_comma]
+                json_string = line[index_of_first_comma+1:]
+                telemetry_dict = json.loads(json_string)
+                return_tuples.append((command_name, telemetry_dict))
+
+    return return_tuples
+
+
+def send_telemetry_best_attempt():
+    """
+    Sends telemetry data from file TELEMETRY_FILE_PATH. The data is preserved if the process
+    is terminated before telemetry is sent, since removal of the TELEMETRY_FILE_PATH is called
+    only once that is completed.
+
+    There is a possibility of duplicate data, since if the telemetry data is sent out, and the
+    process is terminated before the file is deleted, we may end up resending.
+    This is acceptable since it will be rare, and since we have unique IDs for each telemetry
+    event.
+
+    There is a possibility that the process is terminated after telemetry send and file delete,
+    but before we can resent the telemetry send retry counter. This case will also be rare.
+    It will also take care of itself over time, since we will keep filling up new data, and
+    eventually it will send. We may lose some data, but that can be fixed in future changes.
+
+    We are also not currently setting time on the telemetry. We are counting the time as the time
+    sent. There is an entry to track the time, but the default sorting will not work with time
+    necessarily. We accept this right now, since there is not much we do with time data.
 
     :return: None
     """
 
-    telemetry_client = TelemetryClient(INSTRUMENTATION)
-    # This information is also repeated in telemetry_data for ease of search.
-    # This may be moved from one area to another
-    telemetry_client.context.application.ver = get_cli_version_from_pkg()
+    telemetry_tuples = read_telemetry_entries()
 
-    telemetry_client.track_event(command_name, telemetry_data)
+    telemetry_client = TelemetryClient(INSTRUMENTATION)
+
+    for tup in telemetry_tuples:
+        telemetry_client.track_event(tup[0], tup[1])
 
     # This will never end if there is no internet connection, for example.
     telemetry_client.flush()
+
+    # After send has completed, delete the file
+    try:
+        os.remove(TELEMETRY_FILE_PATH)
+    except:  # pylint: disable=bare-except
+        pass
+
+    # After send has completed, clear the telemetry retry counter
+    set_telemetry_send_retry_count(0)
 
 # pylint: disable=invalid-name
 if __name__ == '__main__':
 
     try:
-
-        command = sys.argv[1]
-        call_success = sys.argv[2]
-        platform = sys.argv[3]
-        python_version = sys.argv[4]
-        error_msg = sys.argv[5]
-
-        operation_id = str(uuid4())
-
-        # operation_id is used to ID one instance of a user calling a command.
-
-        telemetry_data_input = {'success': call_success,
-                                'operating_system': platform,
-                                'python_version': python_version,
-                                'operation_id': operation_id,
-                                'error_msg': error_msg,
-                                'sfctl_version': get_cli_version_from_pkg()}
-
         # Using a process because we can kill that on a timer. We cannot kill threads the same way.
         telemetry_name = 'sfctl_telemetry'
         send_current_telemetry_process = Process(target=send_telemetry_best_attempt,
-                                                 name=telemetry_name,
-                                                 args=(command, telemetry_data_input))
-        send_current_telemetry_process.name = telemetry_name
+                                                 name=telemetry_name)
 
         send_current_telemetry_process.start()
         send_current_telemetry_process.join(SINGLE_UPLOAD_TIMEOUT)

--- a/src/sfctl/state.py
+++ b/src/sfctl/state.py
@@ -115,7 +115,7 @@ def set_telemetry_send_retry_count(retry_count):
     set_state_value('telemetry_retry_count', str(retry_count))
 
 
-def increment_telemetry_send_retry_count():
+def increment_telemetry_send_retry_count():  # pylint: disable=invalid-name
     """
     Gets the current telemetry send retry count and increments the value by 1.
     If no value is currently set, set the value to 1.

--- a/src/sfctl/state.py
+++ b/src/sfctl/state.py
@@ -75,10 +75,13 @@ def get_cluster_version_check_time():
 
 
 def set_cluster_version_check_time(custom_time=None):
-    """Set the time that the cluster version was last checked. Set as the current time in UTC.
+    """Set the time that the cluster version was last checked.
     Time values are given in UTC, but no timezone information is set.
 
-    :param custom_time: For testing only. Expects UTC
+    If custom_time is not provided, set as the current time in UTC.
+    If custom_time is provided, set a custom_time.
+
+    :param custom_time: For testing only. Expects UTC, but without time zone information.
     :type custom_time: datetime.datetime object"""
 
     if custom_time is None:
@@ -86,6 +89,48 @@ def set_cluster_version_check_time(custom_time=None):
     else:
         set_state_value('datetime', custom_time.strftime(DATETIME_FORMAT))
 
+
+def get_telemetry_send_retry_count():
+    """
+    Get the number of send telemetry attempts have failed consecutively.
+
+    :return: int representing number of retries.
+             Return None if the value does not exist in state
+    """
+
+    telemetry_retry_count_str = get_state_value('telemetry_retry_count', None)
+
+    if telemetry_retry_count_str is None:
+        return None
+
+    return int(telemetry_retry_count_str)
+
+
+def set_telemetry_send_retry_count(retry_count):
+    """Set the number of send telemetry attempts have failed consecutively.
+
+    :param retry_count: Number of retries for sending telemetry
+    :type retry_count: int"""
+
+    set_state_value('telemetry_retry_count', str(retry_count))
+
+
+def increment_telemetry_send_retry_count():
+    """
+    Gets the current telemetry send retry count and increments the value by 1.
+    If no value is currently set, set the value to 1.
+
+    :return: (int) The new incremented value
+    """
+
+    current_retry_count = get_telemetry_send_retry_count()
+
+    if current_retry_count is None:
+        set_telemetry_send_retry_count(1)
+        return 1
+
+    set_telemetry_send_retry_count(current_retry_count + 1)
+    return current_retry_count + 1
 
 def get_sfctl_version():
     """

--- a/src/sfctl/telemetry.py
+++ b/src/sfctl/telemetry.py
@@ -8,23 +8,36 @@
 
 from sys import platform, version
 from subprocess import Popen
+from datetime import datetime
 import inspect
 import os
-import psutil
+import json
+from uuid import uuid4
+import portalocker
 from knack.log import get_logger
-from sfctl.config import get_telemetry_config
-from sfctl.util import is_help_command
+from sfctl.config import get_telemetry_config, get_cli_version_from_pkg
+from sfctl.state import increment_telemetry_send_retry_count
 
 # knack CLIConfig has been re-purposed to handle state instead.
-SF_CLI_NAME = 'sfctl'
-SF_CLI_TELEMETRY_DIR = os.path.join('~', '.{0}'.format(SF_CLI_NAME))
+SF_CLI_TELEMETRY_NAME = 'sfctl'
+SF_CLI_TELEMETRY_DIR = os.path.join('~', '.{0}'.format(SF_CLI_TELEMETRY_NAME))
 TELEMETRY_FILE_NAME = 'telemetry'
+TELEMETRY_BATCH_CUTOFF = 50  # The number of entries which can be in one telemetry file.
+TELEMETRY_FILE_PATH = os.path.expanduser(os.path.join(SF_CLI_TELEMETRY_DIR, TELEMETRY_FILE_NAME))
+# Number of consecutive telemetry send failures before retrying only intermittently
+TELEMETRY_RETRY_MAX = 5
+# After hitting TELEMETRY_RETRY_MAX, how many command calls before retrying telemetry send
+TELEMETRY_RETRY_INTERVAL = 50
+
+logger = get_logger(__name__)  # pylint: disable=invalid-name
 
 def check_and_send_telemetry(args_list, invocation_ret_val, exception=None):
     """
     Check if telemetry should be sent, and if so, send the telemetry
-    Telemetry should be sent only if the configuration allows for sending telemetry and if
-    the commandline window does not have too many child processes already running.
+    Telemetry should be sent only if the configuration allows for sending telemetry, and if we have
+    batched enough data.
+
+    Telemetry will be sent in the background.
 
     :param args_list: a list of strings, representing the command called along
         with its parameters
@@ -35,30 +48,31 @@ def check_and_send_telemetry(args_list, invocation_ret_val, exception=None):
     :return: None
     """
 
-    logger = get_logger(__name__)
-
+    # Only send telemetry if user has configured it to be on
     if get_telemetry_config():
 
         try:
-            # If there are more than 15 python processes, do not create another process
-            # (do not send telemetry)
-            # len(psutil.Process().parent().children(recursive=True)) does not work, since it is
-            # not able to find orphaned children
-            python_processes_count = 0
 
-            for process in psutil.process_iter():
-                if process.name().find('python') != -1:
-                    python_processes_count += 1
-
-            if python_processes_count > 15:
-                logger.info('Not sending telemetry because python process count exceeds '
-                            'allowable number')
-                return
-
-            # In the background, do some work on checking and sending telemetry for the current call
             command_return_tuple = (invocation_ret_val, str(exception))
 
-            send_telemetry(args_list, command_return_tuple)
+            command_without_params = []
+
+            # Remove the parameters and keep only the command name
+            # Do this by finding the first item which starts with "-"
+            for segment in args_list:
+                if segment.startswith('-'):
+                    break
+                command_without_params.append(segment)
+
+            command_as_str = ' '.join(command_without_params)
+
+            # If the commands_without_params is empty, this means that
+            # sfctl is called. Don't record this, since it will show up as 'None' in telemetry
+            if not command_without_params:
+                # Do not send telemetry
+                return
+
+            batch_or_send_telemetry(command_as_str, command_return_tuple)
 
         except:  # pylint: disable=bare-except
 
@@ -66,51 +80,78 @@ def check_and_send_telemetry(args_list, invocation_ret_val, exception=None):
             ex = sys.exc_info()[0]
 
             # Allow telemetry to fail silently.
+
             logger.info(
                 str.format('Not sending telemetry because python process due to error: {0}', ex))
 
 
-def send_telemetry(command, command_return):
+def batch_or_send_telemetry(command_as_str, command_return):
+    """
+    Check if telemetry should be sent or not on the condition of how many entries are
+    already batched together. If less than TELEMETRY_BATCH_CUTOFF are in a file, do not
+    send telemetry. Add an entry to the file and leave it at that.
+
+    For now, ignore all entries over the initial TELEMETRY_BATCH_CUTOFF count. In the future,
+    allow keeping of a few more file (configurable).
+
+    If telemetry should not be sent yet, then do the batching here (write to the file)
+
+    :param command_as_str: string representing a command without the parameters. For example,
+        'node list'
+    :param command_return: (int, str). int is the returned code,
+        str is the error message on command failure.
+
+    :return: (bool, list[str])
+        True if should send telemetry. False otherwise.
+        If True, the second item in the tuple is a list of strings, with each string representing
+        a json object with format of return from get_telemetry_input_as_dict()
+    """
+
+    telemetry_json = get_telemetry_input_as_dict(command_return)
+
+    # Open file with mode a+
+    # Opens in append and read mode. Pointer is at end of file. Creates new file if files does not
+    # exist
+    with portalocker.Lock(TELEMETRY_FILE_PATH, timeout=1, fail_when_locked=True, mode='a+') as file:
+
+        file.seek(0)  # Read from the start of the file
+        all_lines = file.readlines() # This moves pointer back to the end of the file
+        total_lines = len(all_lines)
+
+        if total_lines == TELEMETRY_BATCH_CUTOFF - 1:  # Last write to file. Sending telemetry
+            file.write('{0}, {1}\n'.format(command_as_str, json.dumps(telemetry_json)))
+            send_telemetry()
+        elif total_lines < TELEMETRY_BATCH_CUTOFF - 1:  # Writing to file. Not sending telemetry
+            file.write('{0}, {1}\n'.format(command_as_str, json.dumps(telemetry_json)))
+        else: # If total lines > TELEMETRY_BATCH_CUTOFF - 1.
+            # Not writing to file. Calling send_telemetry
+            send_telemetry()
+
+
+def send_telemetry():
     """
     Send telemetry to the provided instrumentation key. This does not includes a check to
         previously unsent telemetry for offline work.
 
-    :param command: list representing the command which is given, including the parameters.
-        For example, ['node', 'list', '--max-results', '10']
-    :param command_return: (int, str). int is the returned code,
-        str is the error message on command failure.
+    We don't want to keep retrying if this keeps failing.
+    Increment the telemetry send retry counter in the state file before each attempt.
+    Successful telemetry send will reset the counter.
+    After the TELEMETRY_RETRY_MAX count, only try sending telemetry every TELEMETRY_RETRY_INTERVAL
 
     :return: None
     """
 
-    command_return_code = command_return[0]
-    command_return_msg = command_return[1]
+    # Mark the start of a telemetry send attempt
+    attempt_number = increment_telemetry_send_retry_count()
 
-    command_without_params = []
-
-    # Mark commands which retrieve help text (ex. sfctl -h or sfctl node list -h)
-    is_help_cmd = is_help_command(command)
-
-    # Remove the parameters and keep only the command name
-    # Do this by finding the first item which starts with "-"
-    for segment in command:
-        if segment.startswith('-'):
-            break
-        command_without_params.append(segment)
-
-    # If the commands_without_params is empty, this means that
-    # either sfctl is called, or sfctl -h is called. Don't record this.
-    # Don't record commands asking for help.
-    if is_help_cmd or not command_without_params:
-        # Do not send telemetry
-        return
-
-    command_as_str = ' '.join(command_without_params)
-
-    call_success = True
-
-    if command_return_code != 0:
-        call_success = False
+    # Do not try sending telemetry if we exceed the retry count, and if we are not at the send
+    # interval
+    if attempt_number > TELEMETRY_RETRY_MAX:
+        if ((attempt_number - TELEMETRY_RETRY_MAX) % TELEMETRY_RETRY_INTERVAL) != 0:
+            # Don't bother sending telemetry
+            logger.info('Not sending telemetry due to too many failed attempts.')
+            return
+        logger.info('Sending telemetry because retry interval is met.')
 
     # Get the path of where this file (telemetry.py) is.
     current_file_location = \
@@ -122,7 +163,43 @@ def send_telemetry(command, command_return):
 
     # subprocess.run is the newer version of the call command (python 3.5)
     # If you close the terminal, this process will end as well.
-    Popen(['python', send_telemetry_background_path, command_as_str,
-           str(call_success), platform, version, command_return_msg], close_fds=True)
+    Popen(['python', send_telemetry_background_path], close_fds=True)
 
     return
+
+
+def get_telemetry_input_as_dict(command_return):
+    """
+    Gather the data that needs to be sent along with telemetry
+
+    :param command_return: (int, str). int is the returned code,
+        str is the error message on command failure.
+
+    :return: dict
+        dict: all values are str
+               {'success': call_success,
+                'operating_system': platform,
+                'python_version': python_version,
+                'operation_id': operation_id,
+                'error_msg': error_msg,
+                'sfctl_version': get_cli_version_from_pkg(),
+                'timestamp': time_of_command_call}
+    """
+
+    command_return_code = command_return[0]
+    command_return_msg = command_return[1]
+
+    call_success = True
+
+    if command_return_code != 0:
+        call_success = False
+
+    operation_id = str(uuid4())
+
+    return {'success': str(call_success),
+            'operating_system': platform,
+            'python_version': version,
+            'operation_id': operation_id,
+            'error_msg': command_return_msg,
+            'sfctl_version': get_cli_version_from_pkg(),
+            'timestamp': str(datetime.utcnow())}

--- a/src/sfctl/telemetry.py
+++ b/src/sfctl/telemetry.py
@@ -112,17 +112,17 @@ def batch_or_send_telemetry(command_as_str, command_return):
     # Open file with mode a+
     # Opens in append and read mode. Pointer is at end of file. Creates new file if files does not
     # exist
-    with portalocker.Lock(TELEMETRY_FILE_PATH, timeout=1, fail_when_locked=True, mode='a+') as file:
+    with portalocker.Lock(TELEMETRY_FILE_PATH, timeout=1, fail_when_locked=True, mode='a+') as telemetry_file:  # pylint: disable=line-too-long
 
-        file.seek(0)  # Read from the start of the file
-        all_lines = file.readlines() # This moves pointer back to the end of the file
+        telemetry_file.seek(0)  # Read from the start of the file
+        all_lines = telemetry_file.readlines() # This moves pointer back to the end of the file
         total_lines = len(all_lines)
 
         if total_lines == TELEMETRY_BATCH_CUTOFF - 1:  # Last write to file. Sending telemetry
-            file.write('{0}, {1}\n'.format(command_as_str, json.dumps(telemetry_json)))
+            telemetry_file.write('{0}, {1}\n'.format(command_as_str, json.dumps(telemetry_json)))
             send_telemetry()
         elif total_lines < TELEMETRY_BATCH_CUTOFF - 1:  # Writing to file. Not sending telemetry
-            file.write('{0}, {1}\n'.format(command_as_str, json.dumps(telemetry_json)))
+            telemetry_file.write('{0}, {1}\n'.format(command_as_str, json.dumps(telemetry_json)))
         else: # If total lines > TELEMETRY_BATCH_CUTOFF - 1.
             # Not writing to file. Calling send_telemetry
             send_telemetry()


### PR DESCRIPTION
Improve upon #152 to make telemetry send batched telemetry in order to improve performance.

Telemetry will write to a file and hold on to telemetry to send in chunks. Current value is 50 items per batch. There are limited retries, so that if there is something such as no internet connection, we retry intermittently. 

Verified:

- [ ] Build and test CI passes
- [ ] History and readme updated to reflect changes
- [ ] Package version updated according to semantic versioning rules
- [ ] Tests modified or added, when applicable
- [ ] Updated code owners file, when applicable
- [ ] Read the [PR checklist](https://github.com/Azure/service-fabric-cli/wiki/Checklist)
