### PR TITLE
Fix bug where empty directories are generated in the current location…

### DIFF
--- a/src/README.rst
+++ b/src/README.rst
@@ -16,6 +16,10 @@ To get started, after installation run the following:
 Change Log
 ==========
 
+7.0.1
+----------
+- Fix bug where an empty directory is generated in the current location (#)
+
 7.0.0
 ----------
 - Add upgrade-rollback command for compose deployment (#119)

--- a/src/README.rst
+++ b/src/README.rst
@@ -18,7 +18,7 @@ Change Log
 
 7.0.1
 ----------
-- Fix bug where an empty directory is generated in the current location (#)
+- Fix bug where an empty directory is generated in the current location. Update code for 7.0.1 release (#167)
 
 7.0.0
 ----------

--- a/src/setup.py
+++ b/src/setup.py
@@ -17,7 +17,7 @@ def read(fname):
 
 setup(
     name='sfctl',
-    version='7.0.0',
+    version='7.0.1',
     description='Azure Service Fabric command line',
     long_description=read('README.rst'),
     url='https://github.com/Azure/service-fabric-cli',

--- a/src/sfctl/config.py
+++ b/src/sfctl/config.py
@@ -13,7 +13,7 @@ from knack import CLI
 
 # Default names
 SF_CLI_NAME = 'sfctl'
-SF_CLI_CONFIG_DIR = os.path.join('~', '.{0}'.format(SF_CLI_NAME))
+SF_CLI_CONFIG_DIR = os.path.expanduser(os.path.join('~', '.{0}'.format(SF_CLI_NAME)))
 SF_CLI_ENV_VAR_PREFIX = SF_CLI_NAME
 
 # How often to check sfctl version and cluster version for compatibility with each other (in hours).

--- a/src/sfctl/custom_cluster.py
+++ b/src/sfctl/custom_cluster.py
@@ -260,7 +260,7 @@ def sfctl_cluster_version_matches(cluster_version, sfctl_version):
     :return: True if they are a match. False otherwise.
     """
 
-    if sfctl_version == '7.0.0':
+    if sfctl_version in ['7.0.0', '7.0.1']:
 
         return cluster_version.startswith('6.4')
 

--- a/src/sfctl/state.py
+++ b/src/sfctl/state.py
@@ -17,7 +17,7 @@ from pkg_resources import get_distribution
 
 # Default names
 SF_CLI_NAME = 'sfctl'
-SF_CLI_STATE_DIR = os.path.join('~', '.{0}'.format(SF_CLI_NAME))
+SF_CLI_STATE_DIR = os.path.expanduser(os.path.join('~', '.{0}'.format(SF_CLI_NAME)))
 STATE_FILE_NAME = 'state'
 
 # Format: Year, month, day, hour, minute, second, microsecond

--- a/src/sfctl/telemetry.py
+++ b/src/sfctl/telemetry.py
@@ -20,6 +20,7 @@ from sfctl.state import increment_telemetry_send_retry_count
 
 # knack CLIConfig has been re-purposed to handle state instead.
 SF_CLI_TELEMETRY_NAME = 'sfctl'
+# Should not use SF_CLI_TELEMETRY_DIR directly without calling os.path.expanduser first.
 SF_CLI_TELEMETRY_DIR = os.path.join('~', '.{0}'.format(SF_CLI_TELEMETRY_NAME))
 TELEMETRY_FILE_NAME = 'telemetry'
 TELEMETRY_BATCH_CUTOFF = 50  # The number of entries which can be in one telemetry file.

--- a/src/sfctl/tests/version_test.py
+++ b/src/sfctl/tests/version_test.py
@@ -16,7 +16,7 @@ class VersionTests(unittest.TestCase):
 
         note: this will require changing the sfctl_version on releases
         """
-        sfctl_version = '7.0.0'
+        sfctl_version = '7.0.1'
 
         pipe = Popen('sfctl --version', shell=True, stdout=PIPE, stderr=PIPE)
         # returned_string and err are returned as bytes


### PR DESCRIPTION
… of the command line

In sfctl 7.0.0, there are empty directories generated on sfctl invocation to the location of the command line. This is caused by an upgrade in knack versions. For the 7.0.0 release, sfctl upgraded the knack dependency from 0.1.1 to 0.5.1, and the new issue emerged. The fix is to expand the paths to that sfctl finds the correct location and generates a new folder there, if necessary.

Update for release 7.0.1

Verified:

- [ ] Build and test CI passes
- [ ] History and readme updated to reflect changes
- [ ] Package version updated according to semantic versioning rules
- [ ] Tests modified or added, when applicable
- [ ] Updated code owners file, when applicable
- [ ] Read the [PR checklist](https://github.com/Azure/service-fabric-cli/wiki/Checklist)
