### PR TITLE
Add cli commands for eventstore service to retrieve events

### DIFF
--- a/src/README.rst
+++ b/src/README.rst
@@ -16,6 +16,10 @@ To get started, after installation run the following:
 Change Log
 ==========
 
+7.0.3
+----------
+- Add events commands (sfctl events) to retrieve events through EventStore service if installed.
+
 7.0.2
 ----------
 - Pause telemetry collection. Update code for 7.0.2 release (#172)

--- a/src/setup.py
+++ b/src/setup.py
@@ -17,7 +17,7 @@ def read(fname):
 
 setup(
     name='sfctl',
-    version='7.0.2',
+    version='7.0.3',
     description='Azure Service Fabric command line',
     long_description=read('README.rst'),
     url='https://github.com/Azure/service-fabric-cli',

--- a/src/sfctl/commands.py
+++ b/src/sfctl/commands.py
@@ -256,6 +256,20 @@ class SFCommandLoader(CLICommandsLoader):
             group.command('get', 'get_property_info')
             group.command('delete', 'delete_property')
 
+        with CommandGroup(self, 'events', client_func_path,
+                          client_factory=client_create) as group:
+            group.command('cluster', 'get_cluster_event_list')
+            group.command('all-nodes', 'get_nodes_event_list')
+            group.command('node', 'get_node_event_list')
+            group.command('all-applications', 'get_applications_event_list')
+            group.command('application', 'get_application_event_list')
+            group.command('all-services', 'get_services_event_list')
+            group.command('service', 'get_service_event_list')
+            group.command('all-partitions', 'get_partitions_event_list')
+            group.command('partition', 'get_partition_event_list')
+            group.command('partition-all-replicas', 'get_partition_replicas_event_list')
+            group.command('partition-replica', 'get_partition_replica_event_list')
+
         # ---------------
         # Mesh standard commands
         # ---------------

--- a/src/sfctl/custom_cluster.py
+++ b/src/sfctl/custom_cluster.py
@@ -260,7 +260,7 @@ def sfctl_cluster_version_matches(cluster_version, sfctl_version):
     :return: True if they are a match. False otherwise.
     """
 
-    if sfctl_version in ['7.0.0', '7.0.1', '7.0.2']:
+    if sfctl_version in ['7.0.0', '7.0.1', '7.0.2', '7.0.3']:
 
         return cluster_version.startswith('6.4')
 

--- a/src/sfctl/helps/main.py
+++ b/src/sfctl/helps/main.py
@@ -161,3 +161,8 @@ helps['settings telemetry'] = """
         sfctl version, OS type, python version, the success or failure of the command,
         the error message returned
 """
+
+helps['events'] = """
+    type: group
+    short-summary: Retrieve events from the events store (if EventStore service is already installed)
+"""

--- a/src/sfctl/tests/version_test.py
+++ b/src/sfctl/tests/version_test.py
@@ -16,7 +16,7 @@ class VersionTests(unittest.TestCase):
 
         note: this will require changing the sfctl_version on releases
         """
-        sfctl_version = '7.0.2'
+        sfctl_version = '7.0.3'
 
         pipe = Popen('sfctl --version', shell=True, stdout=PIPE, stderr=PIPE)
         # returned_string and err are returned as bytes


### PR DESCRIPTION
Fixes # .

Changes include:

- New cli commands for EventStore. Allows retrieving events through corresponding REST APIs. 
-
-

Examples:

Command: sfctl events -h

Group
    sfctl events : Retrieve events from the events store (if EventStore service is already
    installed).

Commands:
    all-applications       : Gets all Applications-related events.
    all-nodes              : Gets all Nodes-related Events.
    all-partitions         : Gets all Partitions-related events.
    all-services           : Gets all Services-related events.
    application            : Gets an Application-related events.
    cluster                : Gets all Cluster-related events.
    node                   : Gets a Node-related events.
    partition              : Gets a Partition-related events.
    partition-all-replicas : Gets all Replicas-related events for a Partition.
    partition-replica      : Gets a Partition Replica-related events.
    service                : Gets a Service-related events.

Command: sfctl events application -h

Command
    sfctl events application : Gets an Application-related events.
        The response is list of ApplicationEvent objects.

Arguments
    --application-id [Required] : The identity of the application. This is typically the full name
                                  of the application without the 'fabric:' URI scheme. Starting from
                                  version 6.0, hierarchical names are delimited with the "~"
                                  character. For example, if the application name is
                                  "fabric:/myapp/app1", the application identity would be
                                  "myapp~app1" in 6.0+ and "myapp/app1" in previous versions.
    --end-time-utc   [Required] : The end time of a lookup query in ISO UTC yyyy-MM-ddTHH:mm:ssZ.
    --start-time-utc [Required] : The start time of a lookup query in ISO UTC yyyy-MM-ddTHH:mm:ssZ.
    --events-types-filter       : This is a comma separated string specifying the types of
                                  FabricEvents that should only be included in the response.
    --exclude-analysis-events   : This param disables the retrieval of AnalysisEvents if true is
                                  passed.
    --skip-correlation-lookup   : This param disables the search of CorrelatedEvents information if
                                  true is passed. otherwise the CorrelationEvents get processed and
                                  HasCorrelatedEvents field in every FabricEvent gets populated.
    --timeout -t                : Server timeout in seconds.  Default: 60.

Command: sfctl cluster select --endpoint "http://localhost:19080"

(If EventStoreService is not available)

Command: sfctl events application --application-id "System" --start-time-utc "2018-01-01T00:00:00Z" --end-time-utc "2020-01-01T00:00:00Z"
Service is not installed.

(Else)

Command: sfctl events application --application-id "System" --start-time-utc "2018-01-01T00:00:00Z" --end-time-utc "2020-01-01T00:00:00Z"
[
  {
    "additionalProperties": {},
    "applicationId": "System",
    "category": "StateTransition",
    "codePackageName": "Code",
    "entryPointType": "Exe",
    "eventInstanceId": "ad76ff2c-e1e2-4f13-81a9-9b8babc364c9",
    "exeName": "EventStore.Service.Setup.exe",
    "exitCode": 0,
    "hasCorrelatedEvents": false,
    "hostId": "31ad98b7-a5ee-47e0-82d6-fb41ebf332c0",
    "isExclusive": false,
    "kind": "ApplicationProcessExited",
    "processId": 30248,
    "serviceName": "",
    "servicePackageActivationId": "",
    "servicePackageName": "ES",
    "startTime": "2019-01-07T14:47:48.513717+00:00",
    "timeStamp": "2019-01-07T22:47:50.144460+00:00",
    "unexpectedTermination": true
  },

Verified:

- [ ] Build and test CI passes
- [ ] History and readme updated to reflect changes
- [ ] Package version updated according to semantic versioning rules
- [ ] Tests modified or added, when applicable
- [ ] Updated code owners file, when applicable
- [ ] Read the [PR checklist](https://github.com/Azure/service-fabric-cli/wiki/Checklist)
