### PR TITLE
Adding dependency of exact version of sfmergeutility on sfcli

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -53,7 +53,7 @@ setup(
         'adal',
         'future',
         'applicationinsights',
-        'sfmergeutility',
+        'sfmergeutility==0.1.5',
         'psutil',
         'portalocker'
     ],


### PR DESCRIPTION
Fixes # .

Changes include:

- Adding dependency of exact version of sfmergeutility on sfcli so as to prevent any breakages if APIs diverge on future releases.

Verified:

- [ ] Build and test CI passes
- [ ] History and readme updated to reflect changes
- [ ] Package version updated according to semantic versioning rules
- [ ] Tests modified or added, when applicable
- [ ] Updated code owners file, when applicable
- [ ] Read the [PR checklist](https://github.com/Azure/service-fabric-cli/wiki/Checklist)
