### PR TITLE
Bump required mergeutil ver to 0.1.6

### DIFF
--- a/src/README.rst
+++ b/src/README.rst
@@ -22,6 +22,7 @@ Unreleased
 - Add events commands (sfctl events) to retrieve events through EventStore service if installed (#174)
 - Change serializers, and change formatting of sfctl container invoke-api output (#179)
 - Update Knack version to 0.5.2 (#181)
+- Update sfmergeutility version to 0.1.6 (#183)
 
 7.0.2
 ----------

--- a/src/setup.py
+++ b/src/setup.py
@@ -53,7 +53,7 @@ setup(
         'adal',
         'future',
         'applicationinsights',
-        'sfmergeutility',
+        'sfmergeutility==0.1.5',
         'psutil',
         'portalocker'
     ],

--- a/src/setup.py
+++ b/src/setup.py
@@ -52,7 +52,7 @@ setup(
         'adal',
         'future',
         'applicationinsights',
-        'sfmergeutility==0.1.5',
+        'sfmergeutility==0.1.6',
         'psutil',
         'portalocker'
     ],


### PR DESCRIPTION
Fixes # .

Changes include:

- Bump required sfmergeutility ver to 0.1.6 which contains the security fix to use safe_load instead of yaml.load
-
-

Verified:

- [ ] Build and test CI passes
- [ ] History and readme updated to reflect changes
- [ ] Package version updated according to semantic versioning rules
- [ ] Tests modified or added, when applicable
- [ ] Updated code owners file, when applicable
- [ ] Read the [PR checklist](https://github.com/Azure/service-fabric-cli/wiki/Checklist)
