### PR TITLE
Improve error message

### DIFF
--- a/src/README.rst
+++ b/src/README.rst
@@ -23,7 +23,7 @@ Unreleased
 - Change serializers, and change formatting of sfctl container invoke-api output (#179)
 - Update Knack version to 0.5.2 (#181)
 - Update sfmergeutility version to 0.1.6 (#183)
-- Improve error message (#)
+- Improve error message (#185)
 
 7.0.2
 ----------

--- a/src/README.rst
+++ b/src/README.rst
@@ -23,6 +23,7 @@ Unreleased
 - Change serializers, and change formatting of sfctl container invoke-api output (#179)
 - Update Knack version to 0.5.2 (#181)
 - Update sfmergeutility version to 0.1.6 (#183)
+- Improve error message (#)
 
 7.0.2
 ----------

--- a/src/sfctl/apiclient.py
+++ b/src/sfctl/apiclient.py
@@ -20,9 +20,11 @@ def create(_):
     endpoint = client_endpoint()
 
     if not endpoint:
-        raise CLIError("Connection endpoint not found. "
-                       "Before running sfctl commands, connect to a cluster using "
-                       "the 'sfctl cluster select' command.")
+        raise CLIError('Connection endpoint not found. '
+                       'Before running sfctl commands, connect to a cluster using '
+                       'the "sfctl cluster select" command. '
+                       'If you are seeing this message on Linux after already selecting a cluster, '
+                       'you may need to run the command with sudo.')
 
     no_verify = no_verify_setting()
 


### PR DESCRIPTION
There is a case where sudo permissions may be required when running a command in Linux, but the error message instead says that connection is not found. Improve the error message.

Verified:

- [ ] Build and test CI passes
- [ ] History and readme updated to reflect changes
- [ ] Package version updated according to semantic versioning rules
- [ ] Tests modified or added, when applicable
- [ ] Updated code owners file, when applicable
- [ ] Read the [PR checklist](https://github.com/Azure/service-fabric-cli/wiki/Checklist)
