### PR TITLE
Configuration override commands

### DIFF
--- a/src/README.rst
+++ b/src/README.rst
@@ -18,6 +18,7 @@ Change Log
 
 Unreleased
 ----------
+- Added configuration overrides node commands. These commands will be available in the Service fabric runtime 7.0 version (#206)
 - Provide option to compress packages on application upload. By default, the newly generated compressed package is deleted after successful upload. (#191)
 - Update Create and Update service with new parameter, ServicePlacementTimeLimit (#200)
 

--- a/src/sfctl/commands.py
+++ b/src/sfctl/commands.py
@@ -120,6 +120,18 @@ class SFCommandLoader(CLICommandsLoader):
                 'transition-status',
                 'get_node_transition_progress'
             )
+            group.command(
+                'add-configuration-parameter-overrides',
+                'add_configuration_parameter_overrides'
+            )
+            group.command(
+                'get-configuration-overrides',
+                'get_configuration_overrides'
+            )
+            group.command(
+                'remove-configuration-overrides',
+                'remove_configuration_overrides'
+            )
 
         with CommandGroup(self, 'application', client_func_path,
                           client_factory=client_create) as group:

--- a/src/sfctl/tests/help_text_test.py
+++ b/src/sfctl/tests/help_text_test.py
@@ -342,7 +342,9 @@ class HelpTextTests(unittest.TestCase):
         self.validate_output(
             'sfctl node',
             commands=('disable', 'enable', 'health', 'info', 'list', 'load', 'remove-state',
-                      'report-health', 'restart', 'transition', 'transition-status'))
+                      'report-health', 'restart', 'transition', 'transition-status',
+                      'add-configuration-parameter-overrides', 'get-configuration-overrides',
+                      'remove-configuration-overrides'))
 
         self.validate_output(
             'sfctl partition',

--- a/src/sfctl/tests/request_generation_test.py
+++ b/src/sfctl/tests/request_generation_test.py
@@ -446,11 +446,32 @@ class ServiceFabricRequestTests(ScenarioTest):
              '"RemoveWhenExpired": true}'),
             validate_flat_dictionary)
         self.validate_command(  # restart
-            'sfctl node restart --node-name=nodeName --node-instance-id=ID --create-fabric-dump=True',
-            'POST',
-            '/Nodes/nodeName/$/Restart',
-            ['api-version=6.0'],
-            '{"CreateFabricDump":"True", "NodeInstanceId":"ID"}',
+             'sfctl node restart --node-name=nodeName --node-instance-id=ID --create-fabric-dump=True',
+             'POST',
+             '/Nodes/nodeName/$/Restart',
+             ['api-version=6.0'],
+             '{"CreateFabricDump":"True", "NodeInstanceId":"ID"}',
+             validate_flat_dictionary)
+        self.validate_command(  # remove-configuration-overrides
+             'sfctl node remove-configuration-overrides --node-name=nodeName',
+             'DELETE',
+             '/Nodes/nodeName/$/RemoveConfigurationOverrides',
+             ['api-version=7.0'])            
+        self.validate_command(  # get-configuration-overrides
+             'sfctl node get-configuration-overrides --node-name=nodeName',
+             'GET',
+             '/Nodes/nodeName/$/GetConfigurationOverrides',
+            ['api-version=7.0'])
+        self.validate_command(  # add-configuration-parameter-overrides
+             'sfctl node add-configuration-parameter-overrides --node-name=nodeName --section-name=PlacementAndLoadBalancing ' +
+             '--parameter-name=DummyPLBEnabled --parameter_value=False --force=True,
+             'POST',
+             '/Nodes/nodeName/$/AddConfigurationParameterOverrides',
+             ['api-version=7.0'],
+            ('{"SectionName": "PlacementAndLoadBalancing", '
+             '"ParameterName": "DummyPLBEnabled", '
+             '"ParameterValue": "False", '
+             '"force": true}'),
             validate_flat_dictionary)
 
         # container commands


### PR DESCRIPTION
Fixes # .

Changes include:
Added 3 new commands: add-configuration-parameter-overrides, get-configuration-overrides and remove-configuration-overrides. These will be available in the Service fabric runtime 7.0 version. They can override certain configs on a node level.
Added release notes.

Verified:

- [ ] Build and test CI passes
- [ ] History and readme updated to reflect changes
- [ ] Package version updated according to semantic versioning rules
- [ ] Tests modified or added, when applicable
- [ ] Updated code owners file, when applicable
- [ ] Read the [PR checklist](https://github.com/Azure/service-fabric-cli/wiki/Checklist)
