### PR TITLE
py2 removed.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: python
 python:
-  - 2.7
   - 3.5
   - 3.6
-
+  - 3.8
 # The below lines are a workaround to get python 3.7 support to work.
 # Remove when Travis officially supports 3.7
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,8 @@
 language: python
 python:
-  - 3.5
   - 3.6
+  - 3.7
   - 3.8
-# The below lines are a workaround to get python 3.7 support to work.
-# Remove when Travis officially supports 3.7
-matrix:
-  include:
-    - python: 3.7
-      dist: xenial
-      sudo: true
 
 git:
   depth: 3

--- a/pylintrc
+++ b/pylintrc
@@ -129,7 +129,8 @@ disable=print-statement,
         dict-values-not-iterating,
         similarities,
         import-outside-toplevel,
-        super-with-arguments
+        super-with-arguments,
+        raise-missing-from
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/pylintrc
+++ b/pylintrc
@@ -128,7 +128,8 @@ disable=print-statement,
         dict-keys-not-iterating,
         dict-values-not-iterating,
         similarities,
-        import-outside-toplevel
+        import-outside-toplevel,
+        super-with-arguments
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/src/setup.py
+++ b/src/setup.py
@@ -31,12 +31,12 @@ setup(
         'Environment :: Console',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7'
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8'
     ],
     keywords='servicefabric azure',
-    python_requires='!=3.4,!=3.3,!=3.2,!=3.1,!=3.0,<4',
+    python_requires='>3.5, <4',
     packages=[
         'sfctl',
         'sfctl.helps',

--- a/src/setup.py
+++ b/src/setup.py
@@ -37,7 +37,7 @@ setup(
         'Programming Language :: Python :: 3.7'
     ],
     keywords='servicefabric azure',
-    python_requires='>=2.7,!=3.4,!=3.3,!=3.2,!=3.1,!=3.0,<3.8',
+    python_requires='>=2.7,!=3.4,!=3.3,!=3.2,!=3.1,!=3.0,<4',
     packages=[
         'sfctl',
         'sfctl.helps',

--- a/src/setup.py
+++ b/src/setup.py
@@ -31,13 +31,12 @@ setup(
         'Environment :: Console',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7'
     ],
     keywords='servicefabric azure',
-    python_requires='>=2.7,!=3.4,!=3.3,!=3.2,!=3.1,!=3.0,<4',
+    python_requires='!=3.4,!=3.3,!=3.2,!=3.1,!=3.0,<4',
     packages=[
         'sfctl',
         'sfctl.helps',


### PR DESCRIPTION
removes py2 support from the setup.py and the CI tests.

Changes include:

-
-
-

Verified:

- [ ] Build and test CI passes
- [ ] History and readme updated to reflect changes
- [ ] Package version updated according to semantic versioning rules
- [ ] Tests modified or added, when applicable
- [ ] Updated code owners file, when applicable
- [ ] Read the [PR checklist](https://github.com/Azure/service-fabric-cli/wiki/Checklist)
