### PR TITLE
Add support for showing build tools version in pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,16 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Get versions
+      run: |
+        echo "pip version:"
+        pip -V
+        echo "python version:"
+        python -V
+        echo "git version:"
+        git --version
+        echo "bash version:"
+        bash --version
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,8 @@ jobs:
         git --version
         echo "bash version:"
         bash --version
+        echo "os version:"
+        cat /proc/version
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Changes include:

- Add step to show tool version from build pipeline


Verified:

- [ ] Build and test CI passes
- [ ] History and readme updated to reflect changes
- [ ] Package version updated according to semantic versioning rules
- [ ] Tests modified or added, when applicable
- [ ] Updated code owners file, when applicable
- [ ] Read the [PR checklist](https://github.com/Azure/service-fabric-cli/wiki/Checklist)
