### PR TITLE
Upgrade urllib3 to >= 2.6.0 to remediate CWE-409 decompression bomb vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ contextlib2
 mock
 astroid==2.5.6
 requests==2.32.4
+urllib3>=2.6.0

--- a/src/setup.py
+++ b/src/setup.py
@@ -45,6 +45,7 @@ setup(
     install_requires=[
         'knack==0.6.3',
         'requests==2.32.3',
+        'urllib3>=2.6.0',
         'msrest>=0.5.0',
         'msrestazure',
         'azure-servicefabric==8.2.0.0',


### PR DESCRIPTION
urllib3 versions prior to 2.6.0 are vulnerable to excessive resource consumption
(CWE-409) when streaming compressed HTTP responses. A small amount of highly
compressed data can cause massive memory allocation and high CPU usage on the
client side, even when only a small chunk is requested.

This change adds an explicit lower-bound pin for urllib3>=2.6.0 in both
requirements.txt and src/setup.py install_requires. Previously urllib3 was only
pulled in as a transitive dependency of requests (which allows >=1.21.1,<3),
meaning the vulnerable 1.26.x line could be silently resolved.

Changes include:

- requirements.txt: added urllib3>=2.6.0
- src/setup.py: added urllib3>=2.6.0 to install_requires

Validation:
- pip show urllib3 confirms 2.6.3 is resolved
- Runtime check: requests.packages.urllib3.__version__ == 2.6.3
- verify.bat local: lint passes, 82/90 tests pass (failures are pre-existing,
  unrelated to this change)
- No direct urllib3 imports exist in sfctl source; only consumed indirectly
  via requests

Verified:

- [ ] Build and test CI passes
- [ ] History and readme updated to reflect changes
- [ ] Package version updated according to semantic versioning rules
- [ ] Tests modified or added, when applicable
- [ ] Updated code owners file, when applicable
- [ ] Read the [PR checklist](https://github.com/Azure/service-fabric-cli/wiki/Checklist)
