### PR TITLE
fix: upgrade urllib3 to >= 2.7.0 to remediate CVE-2026-44431 and CVE-…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ contextlib2
 mock
 astroid==2.5.6
 requests==2.32.4
-urllib3>=2.6.0
+urllib3>=2.7.0

--- a/src/setup.py
+++ b/src/setup.py
@@ -45,7 +45,7 @@ setup(
     install_requires=[
         'knack==0.6.3',
         'requests==2.32.3',
-        'urllib3>=2.6.0',
+        'urllib3>=2.7.0',
         'msrest>=0.5.0',
         'msrestazure',
         'azure-servicefabric==8.2.0.0',


### PR DESCRIPTION
Bumps the urllib3 floor from >=2.6.0 to >=2.7.0 to remediate two CVEs flagged by Component Governance:

- CVE-2026-44431
- CVE-2026-44432

Files changed:
- requirements.txt
- src/setup.py

Verified locally with Python 3.11.9 in a clean venv:
- `pip install -r requirements.txt` resolves urllib3==2.7.0
- `pip install -e ./src` succeeds; `pip check` reports no broken requirements
- `sfctl --version` runs cleanly

Internal tracking: S360 CG repo 184050, alerts 16002455 and 16002454.